### PR TITLE
Enable wait for confirmed by default

### DIFF
--- a/custom_components/amber_express/const.py
+++ b/custom_components/amber_express/const.py
@@ -45,7 +45,7 @@ DEFAULT_PRICING_MODE: Final = PRICING_MODE_APP
 DEFAULT_FORECAST_INTERVALS: Final = 288
 DEFAULT_ENABLE_WEBSOCKET: Final = True
 DEFAULT_WAIT_FOR_CONFIRMED: Final = True  # Keep polling until non-estimated price
-DEFAULT_CONFIRMATION_TIMEOUT: Final = 60  # seconds to wait for confirmed price
+DEFAULT_CONFIRMATION_TIMEOUT: Final = 45  # seconds to wait for confirmed price
 DEFAULT_DEMAND_WINDOW_PRICE: Final = 0.0  # $/kWh penalty during demand window
 
 # Sensor attributes


### PR DESCRIPTION
The estimates by amber seem to be more noise than signal, so my default recommendation has changed.