### PR TITLE
fix: suppress Pydantic V1 warning on Python 3.14+

### DIFF
--- a/custom_components/amber_express/coordinator.py
+++ b/custom_components/amber_express/coordinator.py
@@ -1,6 +1,14 @@
 """Data coordinator for Amber Express integration."""
 
+
 from __future__ import annotations
+
+import warnings
+warnings.filterwarnings(
+    "ignore",
+    message="Core Pydantic V1 functionality",
+    category=UserWarning,
+)
 
 from datetime import UTC, datetime, timedelta
 import logging


### PR DESCRIPTION
Fixes #55 

## Problem
When running on Python 3.14, the following warning appears in Home Assistant logs:

UserWarning: Core Pydantic V1 functionality isn't compatible with Python 3.14 or greater
at amberelectric/api/amber_api.py:21

This is caused by the `amberelectric` SDK internally using `pydantic.v1`, 
which is incompatible with Python 3.14+.

So IAdded a `warnings.filterwarnings` call in `coordinator.py` to suppress 
this warning before the library is imported.
A permanent fix would require the `amberelectric` SDK to migrate from 
Pydantic V1 to V2, which is an upstream issue.