### PR TITLE
Improve API failure handling

### DIFF
--- a/custom_components/amber_express/api/client.py
+++ b/custom_components/amber_express/api/client.py
@@ -165,10 +165,12 @@ class AmberApiClient:
                 self._rate_limiter.record_rate_limit(reset_at, remaining=remaining)
                 raise RateLimitedError(reset_at) from err
 
+            self._rate_limiter.record_server_error()
             msg = f"Failed to fetch sites: {err}"
             raise AmberApiError(msg, status) from err
         except (urllib3.exceptions.HTTPError, OSError) as err:
             self._last_api_status = HTTP_NETWORK_ERROR
+            self._rate_limiter.record_server_error()
             msg = f"Network error talking to Amber: {type(err).__name__}: {err}"
             raise AmberApiError(msg, HTTP_NETWORK_ERROR) from err
 
@@ -242,10 +244,12 @@ class AmberApiClient:
                 self._rate_limiter.record_rate_limit(reset_at, remaining=remaining)
                 raise RateLimitedError(reset_at) from err
 
+            self._rate_limiter.record_server_error()
             msg = f"Amber API error ({status}): {err.reason}"
             raise AmberApiError(msg, status) from err
         except (urllib3.exceptions.HTTPError, OSError) as err:
             self._last_api_status = HTTP_NETWORK_ERROR
+            self._rate_limiter.record_server_error()
             msg = f"Network error talking to Amber: {type(err).__name__}: {err}"
             raise AmberApiError(msg, HTTP_NETWORK_ERROR) from err
 

--- a/custom_components/amber_express/api/rate_limiter.py
+++ b/custom_components/amber_express/api/rate_limiter.py
@@ -11,21 +11,22 @@ _QUOTA_WARNING_THRESHOLD = 5
 
 
 class ExponentialBackoffRateLimiter:
-    """Manages exponential backoff for rate-limited API calls.
+    """Manage exponential backoff for rate-limited and failed API calls.
 
     Responsibilities:
     - Tracking whether we're currently in a rate-limit backoff period
     - Recording rate limit events (429 responses) and calculating backoff duration
+    - Recording server and network errors
     - Using API-provided reset time when available, falling back to exponential backoff
-    - Resetting backoff on successful API calls
+    - Resetting all failure state on successful API calls
     - Providing remaining seconds until rate limit expires
 
     The backoff strategy:
-    1. First consecutive 429 is ignored (no backoff) to tolerate spurious server-load 429s
-    2. Second consecutive 429: if API provides ratelimit-reset header, use that + 2s buffer;
-       otherwise start at initial_backoff (1s) and double on each further consecutive 429
+    1. First consecutive error is ignored to tolerate a transient failure
+    2. Second consecutive error starts at initial_backoff (1s) and doubles on each
+       further error; a 429-provided reset time takes precedence
     3. Cap at max_backoff (300s / 5 minutes)
-    4. Reset to 0 on any successful API call (including resetting the consecutive counter)
+    4. Reset to 0 on any successful API call
 
     This class is shared between AmberApiClient (which records events) and the
     coordinator (which checks before scheduling polls).
@@ -40,7 +41,7 @@ class ExponentialBackoffRateLimiter:
         """Initialize the rate limiter.
 
         Args:
-            initial_backoff: Initial backoff duration in seconds (used from 2nd 429 onward)
+            initial_backoff: Initial backoff duration in seconds (used from 2nd error onward)
             max_backoff: Maximum backoff duration in seconds
 
         """
@@ -48,7 +49,7 @@ class ExponentialBackoffRateLimiter:
         self._max_backoff = max_backoff
         self._backoff_seconds = 0
         self._rate_limit_until: datetime | None = None
-        self._consecutive_429s = 0
+        self._consecutive_errors = 0
 
     def is_limited(self) -> bool:
         """Check if we're currently rate limited.
@@ -74,10 +75,10 @@ class ExponentialBackoffRateLimiter:
         return max(0, remaining)
 
     def record_success(self) -> None:
-        """Record a successful API call, resetting backoff and consecutive 429 count."""
+        """Record a successful API call and reset failure state."""
         self._backoff_seconds = 0
         self._rate_limit_until = None
-        self._consecutive_429s = 0
+        self._consecutive_errors = 0
 
     def record_rate_limit(self, reset_at: datetime | None, *, remaining: int | None = None) -> datetime | None:
         """Record a rate limit event and set backoff.
@@ -97,10 +98,10 @@ class ExponentialBackoffRateLimiter:
             When the rate limit expires, or None if first 429 was ignored
 
         """
-        self._consecutive_429s += 1
+        self._consecutive_errors += 1
         now = datetime.now(UTC)
 
-        if self._consecutive_429s == 1:
+        if self._consecutive_errors == 1:
             _LOGGER.debug("Rate limited (429), ignoring first occurrence")
             return None
 
@@ -114,22 +115,36 @@ class ExponentialBackoffRateLimiter:
                 "Rate limited (429). Waiting until %s (from API reset header)",
                 self._rate_limit_until.strftime("%H:%M:%S"),
             )
-        elif self._backoff_seconds == 0:
-            self._backoff_seconds = self._initial_backoff
-            self._rate_limit_until = now + timedelta(seconds=self._backoff_seconds)
-            log(
-                "Rate limited (429). Backing off for %d seconds",
-                self._backoff_seconds,
-            )
         else:
-            self._backoff_seconds = min(self._backoff_seconds * 2, self._max_backoff)
-            self._rate_limit_until = now + timedelta(seconds=self._backoff_seconds)
+            was_backing_off = self._backoff_seconds > 0
+            self._start_exponential_backoff(now)
             log(
-                "Rate limited (429). Backing off for %d seconds (exponential)",
+                "Rate limited (429). Backing off for %d seconds%s",
                 self._backoff_seconds,
+                " (exponential)" if was_backing_off else "",
             )
 
         return self._rate_limit_until
+
+    def record_server_error(self) -> datetime | None:
+        """Record a server error and apply exponential backoff."""
+        self._consecutive_errors += 1
+
+        if self._consecutive_errors == 1:
+            _LOGGER.debug("Server error, ignoring first occurrence")
+            return None
+
+        self._start_exponential_backoff(datetime.now(UTC))
+        _LOGGER.warning("Server error, backing off for %d seconds", self._backoff_seconds)
+        return self._rate_limit_until
+
+    def _start_exponential_backoff(self, now: datetime) -> None:
+        """Start or increase exponential backoff."""
+        if self._backoff_seconds == 0:
+            self._backoff_seconds = self._initial_backoff
+        else:
+            self._backoff_seconds = min(self._backoff_seconds * 2, self._max_backoff)
+        self._rate_limit_until = now + timedelta(seconds=self._backoff_seconds)
 
     @property
     def rate_limit_until(self) -> datetime | None:

--- a/custom_components/amber_express/api/tests/test_client.py
+++ b/custom_components/amber_express/api/tests/test_client.py
@@ -173,6 +173,25 @@ class TestAmberApiClient:
             assert exc_info.value.status == 500
             assert api_client.last_status == 500
 
+    async def test_fetch_sites_server_errors_trigger_backoff(
+        self,
+        api_client: AmberApiClient,
+        rate_limiter: ExponentialBackoffRateLimiter,
+    ) -> None:
+        """Test consecutive site server errors trigger exponential backoff."""
+        with patch.object(
+            api_client._hass,
+            "async_add_executor_job",
+            new=AsyncMock(side_effect=ApiException(status=502)),
+        ):
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_sites()
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_sites()
+
+        assert rate_limiter.current_backoff == 1
+        assert rate_limiter.is_limited() is True
+
     @pytest.mark.parametrize(
         "network_error",
         [
@@ -197,6 +216,25 @@ class TestAmberApiClient:
 
             assert exc_info.value.status == 0
             assert api_client.last_status == 0
+
+    async def test_fetch_sites_network_errors_trigger_backoff(
+        self,
+        api_client: AmberApiClient,
+        rate_limiter: ExponentialBackoffRateLimiter,
+    ) -> None:
+        """Test consecutive site network errors trigger exponential backoff."""
+        with patch.object(
+            api_client._hass,
+            "async_add_executor_job",
+            new=AsyncMock(side_effect=OSError("Network is unreachable")),
+        ):
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_sites()
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_sites()
+
+        assert rate_limiter.current_backoff == 1
+        assert rate_limiter.is_limited() is True
 
     async def test_fetch_sites_rate_limited(
         self, api_client: AmberApiClient, rate_limiter: ExponentialBackoffRateLimiter
@@ -302,6 +340,25 @@ class TestAmberApiClient:
             assert exc_info.value.status == 503
             assert api_client.last_status == 503
 
+    async def test_fetch_current_prices_server_errors_trigger_backoff(
+        self,
+        api_client: AmberApiClient,
+        rate_limiter: ExponentialBackoffRateLimiter,
+    ) -> None:
+        """Test consecutive server errors trigger exponential backoff."""
+        with patch.object(
+            api_client._hass,
+            "async_add_executor_job",
+            new=AsyncMock(side_effect=ApiException(status=500)),
+        ):
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_current_prices("test_site")
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_current_prices("test_site")
+
+        assert rate_limiter.current_backoff == 1
+        assert rate_limiter.is_limited() is True
+
     @pytest.mark.parametrize(
         "network_error",
         [
@@ -326,6 +383,25 @@ class TestAmberApiClient:
 
             assert exc_info.value.status == 0
             assert api_client.last_status == 0
+
+    async def test_fetch_current_prices_network_errors_trigger_backoff(
+        self,
+        api_client: AmberApiClient,
+        rate_limiter: ExponentialBackoffRateLimiter,
+    ) -> None:
+        """Test consecutive network errors trigger exponential backoff."""
+        with patch.object(
+            api_client._hass,
+            "async_add_executor_job",
+            new=AsyncMock(side_effect=OSError("Network is unreachable")),
+        ):
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_current_prices("test_site")
+            with pytest.raises(AmberApiError):
+                await api_client.fetch_current_prices("test_site")
+
+        assert rate_limiter.current_backoff == 1
+        assert rate_limiter.is_limited() is True
 
     async def test_fetch_current_prices_rate_limit_triggers_backoff(
         self, api_client: AmberApiClient, rate_limiter: ExponentialBackoffRateLimiter

--- a/custom_components/amber_express/api/tests/test_rate_limiter.py
+++ b/custom_components/amber_express/api/tests/test_rate_limiter.py
@@ -232,6 +232,24 @@ class TestRecordRateLimit:
         assert limiter.current_backoff == 10
 
 
+class TestRecordServerError:
+    """Tests for record_server_error method."""
+
+    def test_consecutive_server_errors_back_off_exponentially(self) -> None:
+        """Test repeated server errors use exponential backoff after one grace."""
+        limiter = ExponentialBackoffRateLimiter(initial_backoff=10, max_backoff=300)
+
+        limiter.record_server_error()
+        assert limiter.current_backoff == 0
+
+        limiter.record_server_error()
+        assert limiter.current_backoff == 10
+
+        limiter._rate_limit_until = None
+        limiter.record_server_error()
+        assert limiter.current_backoff == 20
+
+
 class TestBackoffSequence:
     """Tests for complete backoff sequences."""
 

--- a/custom_components/amber_express/coordinator.py
+++ b/custom_components/amber_express/coordinator.py
@@ -461,14 +461,12 @@ class AmberDataCoordinator(DataUpdateCoordinator[CoordinatorData]):
                 next_intervals=next_intervals,
                 resolution=resolution,
             )
+            self._polling_manager.update_budget(self._api_client.rate_limit_info)
         except RateLimitedError:
             return
         except AmberApiError as err:
             _LOGGER.warning("API error: %s", err)
             return
-        finally:
-            # Update polling manager with rate limit info regardless of success/failure
-            self._polling_manager.update_budget(self._api_client.rate_limit_info)
 
         # Process the intervals
         data = self._interval_processor.process_intervals(intervals)

--- a/custom_components/amber_express/tests/test_coordinator.py
+++ b/custom_components/amber_express/tests/test_coordinator.py
@@ -359,12 +359,17 @@ class TestAmberDataCoordinator:
 
     async def test_fetch_amber_data_api_error(self, coordinator: AmberDataCoordinator) -> None:
         """Test _fetch_amber_data handles API errors."""
-        with patch.object(
-            coordinator._api_client,
-            "fetch_current_prices",
-            new=AsyncMock(side_effect=AmberApiError("API error", 500)),
+        with (
+            patch.object(
+                coordinator._api_client,
+                "fetch_current_prices",
+                new=AsyncMock(side_effect=AmberApiError("API error", 500)),
+            ),
+            patch.object(coordinator._polling_manager, "update_budget") as mock_update_budget,
         ):
             await coordinator._fetch_amber_data()
+
+        mock_update_budget.assert_not_called()
 
     async def test_fetch_amber_data_uses_configured_forecast_intervals(self, coordinator: AmberDataCoordinator) -> None:
         """Test _fetch_amber_data uses forecast interval count from subentry config."""


### PR DESCRIPTION
The latest Amber outage was not handled well Amber Express. Each 500 error would essentially be ignored and polling would just continue to spam the API every second.

This changes error handling such that 500s are handled the same as 429s, which invokes the exponential backoff path.